### PR TITLE
Update the AVR C ABI description

### DIFF
--- a/src/librustc_trans/cabi_avr.rs
+++ b/src/librustc_trans/cabi_avr.rs
@@ -10,159 +10,35 @@
 
 #![allow(non_upper_case_globals)]
 
-use libc::c_uint;
-use llvm::{self, Integer, Pointer, Float, Double, Struct, Array, Vector};
-use abi::{FnType, ArgType};
+use abi::{FnType, ArgType, LayoutExt};
 use context::CrateContext;
-use type_::Type;
 
-use std::cmp;
-
-fn align_up_to(off: usize, a: usize) -> usize {
-    return (off + a - 1) / a * a;
-}
-
-fn align(off: usize, ty: Type) -> usize {
-    let a = ty_align(ty);
-    return align_up_to(off, a);
-}
-
-fn ty_align(ty: Type) -> usize {
-    match ty.kind() {
-        Integer => ((ty.int_width() as usize) + 7) / 8,
-        Pointer => 2,
-        Float => 4,
-        Double => 4,
-        Struct => {
-          if ty.is_packed() {
-            1
-          } else {
-            let str_tys = ty.field_types();
-            str_tys.iter().fold(1, |a, t| cmp::max(a, ty_align(*t)))
-          }
-        }
-        Array => {
-            let elt = ty.element_type();
-            ty_align(elt)
-        }
-        Vector => {
-            let len = ty.vector_length();
-            let elt = ty.element_type();
-            ty_align(elt) * len
-        }
-        _ => panic!("ty_align: unhandled type")
-    }
-}
-
-fn ty_size(ty: Type) -> usize {
-    match ty.kind() {
-        Integer => ((ty.int_width() as usize) + 7) / 8,
-        Pointer => 2,
-        Float => 4,
-        Double => 4,
-        Struct => {
-            if ty.is_packed() {
-                let str_tys = ty.field_types();
-                str_tys.iter().fold(0, |s, t| s + ty_size(*t))
-            } else {
-                let str_tys = ty.field_types();
-                let size = str_tys.iter().fold(0, |s, t| align(s, *t) + ty_size(*t));
-                align(size, ty)
-            }
-        }
-        Array => {
-            let len = ty.array_length();
-            let elt = ty.element_type();
-            let eltsz = ty_size(elt);
-            len * eltsz
-        }
-        Vector => {
-            let len = ty.vector_length();
-            let elt = ty.element_type();
-            let eltsz = ty_size(elt);
-            len * eltsz
-        }
-        _ => panic!("ty_size: unhandled type")
-    }
-}
-
-fn classify_ret_ty(ccx: &CrateContext, ret: &mut ArgType) {
-    if is_reg_ty(ret.ty) {
+fn classify_ret_ty<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ret: &mut ArgType<'tcx>) {
+    if ret.layout.is_aggregate()  {
         ret.extend_integer_width_to(8); // Is 8 correct?
     } else {
         ret.make_indirect(ccx);
     }
 }
 
-fn classify_arg_ty(ccx: &CrateContext, arg: &mut ArgType, offset: &mut usize) {
-    let orig_offset = *offset;
-    let size = ty_size(arg.ty) * 8;
-    let mut align = ty_align(arg.ty);
-
-    align = cmp::min(cmp::max(align, 4), 8);
-    *offset = align_up_to(*offset, align);
-    *offset += align_up_to(size, align * 8) / 8;
-
-    if is_reg_ty(arg.ty) {
+fn classify_arg_ty<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, arg: &mut ArgType<'tcx>) {
+    if arg.layout.is_aggregate() {
         arg.extend_integer_width_to(8);
     } else {
-        arg.cast = Some(struct_ty(ccx, arg.ty));
-        arg.pad = padding_ty(ccx, align, orig_offset);
+        arg.make_indirect(ccx);
     }
 }
 
-fn is_reg_ty(ty: Type) -> bool {
-    return match ty.kind() {
-        Integer
-        | Pointer
-        | Float
-        | Double
-        | Vector => true,
-        _ => false
-    };
-}
-
-fn padding_ty(ccx: &CrateContext, align: usize, offset: usize) -> Option<Type> {
-    if ((align - 1 ) & offset) > 0 {
-        Some(Type::i32(ccx))
-    } else {
-        None
-    }
-}
-
-fn coerce_to_int(ccx: &CrateContext, size: usize) -> Vec<Type> {
-    let int_ty = Type::i32(ccx);
-    let mut args = Vec::new();
-
-    let mut n = size / 32;
-    while n > 0 {
-        args.push(int_ty);
-        n -= 1;
-    }
-
-    let r = size % 32;
-    if r > 0 {
-        unsafe {
-            args.push(Type::from_ref(llvm::LLVMIntTypeInContext(ccx.llcx(), r as c_uint)));
-        }
-    }
-
-    args
-}
-
-fn struct_ty(ccx: &CrateContext, ty: Type) -> Type {
-    let size = ty_size(ty) * 8;
-    Type::struct_(ccx, &coerce_to_int(ccx, size), false)
-}
-
-pub fn compute_abi_info(ccx: &CrateContext, fty: &mut FnType) {
+pub fn compute_abi_info<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fty: &mut FnType<'tcx>) {
     if !fty.ret.is_ignore() {
         classify_ret_ty(ccx, &mut fty.ret);
     }
 
-    let mut offset = if fty.ret.is_indirect() { 4 } else { 0 };
-
     for arg in &mut fty.args {
-        classify_arg_ty(ccx, arg, &mut offset);
-    };
+        if arg.is_ignore() {
+            continue;
+        }
+
+        classify_arg_ty(ccx, arg);
+    }
 }

--- a/src/librustc_trans/cabi_avr.rs
+++ b/src/librustc_trans/cabi_avr.rs
@@ -10,160 +10,159 @@
 
 #![allow(non_upper_case_globals)]
 
-// use libc::c_uint;
-// use llvm::{self, Integer, Pointer, Float, Double, Struct, Array, Vector};
-use abi::FnType;//, ArgType};
+use libc::c_uint;
+use llvm::{self, Integer, Pointer, Float, Double, Struct, Array, Vector};
+use abi::{FnType, ArgType};
 use context::CrateContext;
-// use type_::Type;
+use type_::Type;
 
-// use std::cmp;
+use std::cmp;
 
-// fn align_up_to(off: usize, a: usize) -> usize {
-//     return (off + a - 1) / a * a;
-// }
+fn align_up_to(off: usize, a: usize) -> usize {
+    return (off + a - 1) / a * a;
+}
 
-// fn align(off: usize, ty: Type) -> usize {
-//     let a = ty_align(ty);
-//     return align_up_to(off, a);
-// }
+fn align(off: usize, ty: Type) -> usize {
+    let a = ty_align(ty);
+    return align_up_to(off, a);
+}
 
-// fn ty_align(ty: Type) -> usize {
-//     match ty.kind() {
-//         Integer => ((ty.int_width() as usize) + 7) / 8,
-//         Pointer => 2,
-//         Float => 4,
-//         Double => 4,
-//         Struct => {
-//           if ty.is_packed() {
-//             1
-//           } else {
-//             let str_tys = ty.field_types();
-//             str_tys.iter().fold(1, |a, t| cmp::max(a, ty_align(*t)))
-//           }
-//         }
-//         Array => {
-//             let elt = ty.element_type();
-//             ty_align(elt)
-//         }
-//         Vector => {
-//             let len = ty.vector_length();
-//             let elt = ty.element_type();
-//             ty_align(elt) * len
-//         }
-//         _ => panic!("ty_align: unhandled type")
-//     }
-// }
+fn ty_align(ty: Type) -> usize {
+    match ty.kind() {
+        Integer => ((ty.int_width() as usize) + 7) / 8,
+        Pointer => 2,
+        Float => 4,
+        Double => 4,
+        Struct => {
+          if ty.is_packed() {
+            1
+          } else {
+            let str_tys = ty.field_types();
+            str_tys.iter().fold(1, |a, t| cmp::max(a, ty_align(*t)))
+          }
+        }
+        Array => {
+            let elt = ty.element_type();
+            ty_align(elt)
+        }
+        Vector => {
+            let len = ty.vector_length();
+            let elt = ty.element_type();
+            ty_align(elt) * len
+        }
+        _ => panic!("ty_align: unhandled type")
+    }
+}
 
-// fn ty_size(ty: Type) -> usize {
-//     match ty.kind() {
-//         Integer => ((ty.int_width() as usize) + 7) / 8,
-//         Pointer => 2,
-//         Float => 4,
-//         Double => 4,
-//         Struct => {
-//             if ty.is_packed() {
-//                 let str_tys = ty.field_types();
-//                 str_tys.iter().fold(0, |s, t| s + ty_size(*t))
-//             } else {
-//                 let str_tys = ty.field_types();
-//                 let size = str_tys.iter().fold(0, |s, t| align(s, *t) + ty_size(*t));
-//                 align(size, ty)
-//             }
-//         }
-//         Array => {
-//             let len = ty.array_length();
-//             let elt = ty.element_type();
-//             let eltsz = ty_size(elt);
-//             len * eltsz
-//         }
-//         Vector => {
-//             let len = ty.vector_length();
-//             let elt = ty.element_type();
-//             let eltsz = ty_size(elt);
-//             len * eltsz
-//         }
-//         _ => panic!("ty_size: unhandled type")
-//     }
-// }
+fn ty_size(ty: Type) -> usize {
+    match ty.kind() {
+        Integer => ((ty.int_width() as usize) + 7) / 8,
+        Pointer => 2,
+        Float => 4,
+        Double => 4,
+        Struct => {
+            if ty.is_packed() {
+                let str_tys = ty.field_types();
+                str_tys.iter().fold(0, |s, t| s + ty_size(*t))
+            } else {
+                let str_tys = ty.field_types();
+                let size = str_tys.iter().fold(0, |s, t| align(s, *t) + ty_size(*t));
+                align(size, ty)
+            }
+        }
+        Array => {
+            let len = ty.array_length();
+            let elt = ty.element_type();
+            let eltsz = ty_size(elt);
+            len * eltsz
+        }
+        Vector => {
+            let len = ty.vector_length();
+            let elt = ty.element_type();
+            let eltsz = ty_size(elt);
+            len * eltsz
+        }
+        _ => panic!("ty_size: unhandled type")
+    }
+}
 
-// fn classify_ret_ty(ccx: &CrateContext, ret: &mut ArgType) {
-//     if is_reg_ty(ret.ty) {
-//         ret.extend_integer_width_to(8); // Is 8 correct?
-//     } else {
-//         ret.make_indirect(ccx);
-//     }
-// }
+fn classify_ret_ty(ccx: &CrateContext, ret: &mut ArgType) {
+    if is_reg_ty(ret.ty) {
+        ret.extend_integer_width_to(8); // Is 8 correct?
+    } else {
+        ret.make_indirect(ccx);
+    }
+}
 
-// fn classify_arg_ty(ccx: &CrateContext, arg: &mut ArgType, offset: &mut usize) {
-//     let orig_offset = *offset;
-//     let size = ty_size(arg.ty) * 8;
-//     let mut align = ty_align(arg.ty);
+fn classify_arg_ty(ccx: &CrateContext, arg: &mut ArgType, offset: &mut usize) {
+    let orig_offset = *offset;
+    let size = ty_size(arg.ty) * 8;
+    let mut align = ty_align(arg.ty);
 
-//     align = cmp::min(cmp::max(align, 4), 8);
-//     *offset = align_up_to(*offset, align);
-//     *offset += align_up_to(size, align * 8) / 8;
+    align = cmp::min(cmp::max(align, 4), 8);
+    *offset = align_up_to(*offset, align);
+    *offset += align_up_to(size, align * 8) / 8;
 
-//     if is_reg_ty(arg.ty) {
-//         arg.extend_integer_width_to(8);
-//     } else {
-//         arg.cast = Some(struct_ty(ccx, arg.ty));
-//         arg.pad = padding_ty(ccx, align, orig_offset);
-//     }
-// }
+    if is_reg_ty(arg.ty) {
+        arg.extend_integer_width_to(8);
+    } else {
+        arg.cast = Some(struct_ty(ccx, arg.ty));
+        arg.pad = padding_ty(ccx, align, orig_offset);
+    }
+}
 
-// fn is_reg_ty(ty: Type) -> bool {
-//     return match ty.kind() {
-//         Integer
-//         | Pointer
-//         | Float
-//         | Double
-//         | Vector => true,
-//         _ => false
-//     };
-// }
+fn is_reg_ty(ty: Type) -> bool {
+    return match ty.kind() {
+        Integer
+        | Pointer
+        | Float
+        | Double
+        | Vector => true,
+        _ => false
+    };
+}
 
-// fn padding_ty(ccx: &CrateContext, align: usize, offset: usize) -> Option<Type> {
-//     if ((align - 1 ) & offset) > 0 {
-//         Some(Type::i32(ccx))
-//     } else {
-//         None
-//     }
-// }
+fn padding_ty(ccx: &CrateContext, align: usize, offset: usize) -> Option<Type> {
+    if ((align - 1 ) & offset) > 0 {
+        Some(Type::i32(ccx))
+    } else {
+        None
+    }
+}
 
-// fn coerce_to_int(ccx: &CrateContext, size: usize) -> Vec<Type> {
-//     let int_ty = Type::i32(ccx);
-//     let mut args = Vec::new();
+fn coerce_to_int(ccx: &CrateContext, size: usize) -> Vec<Type> {
+    let int_ty = Type::i32(ccx);
+    let mut args = Vec::new();
 
-//     let mut n = size / 32;
-//     while n > 0 {
-//         args.push(int_ty);
-//         n -= 1;
-//     }
+    let mut n = size / 32;
+    while n > 0 {
+        args.push(int_ty);
+        n -= 1;
+    }
 
-//     let r = size % 32;
-//     if r > 0 {
-//         unsafe {
-//             args.push(Type::from_ref(llvm::LLVMIntTypeInContext(ccx.llcx(), r as c_uint)));
-//         }
-//     }
+    let r = size % 32;
+    if r > 0 {
+        unsafe {
+            args.push(Type::from_ref(llvm::LLVMIntTypeInContext(ccx.llcx(), r as c_uint)));
+        }
+    }
 
-//     args
-// }
+    args
+}
 
-// fn struct_ty(ccx: &CrateContext, ty: Type) -> Type {
-//     let size = ty_size(ty) * 8;
-//     Type::struct_(ccx, &coerce_to_int(ccx, size), false)
-// }
+fn struct_ty(ccx: &CrateContext, ty: Type) -> Type {
+    let size = ty_size(ty) * 8;
+    Type::struct_(ccx, &coerce_to_int(ccx, size), false)
+}
 
-pub fn compute_abi_info(_ccx: &CrateContext, _fty: &mut FnType) {
-    unimplemented!()
-    // if !fty.ret.is_ignore() {
-    //     classify_ret_ty(ccx, &mut fty.ret);
-    // }
+pub fn compute_abi_info(ccx: &CrateContext, fty: &mut FnType) {
+    if !fty.ret.is_ignore() {
+        classify_ret_ty(ccx, &mut fty.ret);
+    }
 
-    // let mut offset = if fty.ret.is_indirect() { 4 } else { 0 };
+    let mut offset = if fty.ret.is_indirect() { 4 } else { 0 };
 
-    // for arg in &mut fty.args {
-    //     classify_arg_ty(ccx, arg, &mut offset);
-    // };
+    for arg in &mut fty.args {
+        classify_arg_ty(ccx, arg, &mut offset);
+    };
 }


### PR DESCRIPTION
f0636b61c7f made some drastic changes to how target ABIs are specified within Rust.

In order to make this patch, I looked at `cabi_msp430.rs` and `cabi_mips.rs` for inspiration.

@shepmaster 